### PR TITLE
ci(security): use takumi guard

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,4 +18,7 @@ jobs:
   test:
     uses: ./.github/workflows/workflow_call_test.yaml
     permissions:
+      id-token: write
       contents: read
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}

--- a/.github/workflows/workflow_call_go_test.yaml
+++ b/.github/workflows/workflow_call_go_test.yaml
@@ -1,16 +1,27 @@
 ---
 name: wc-test
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 jobs:
   test:
     timeout-minutes: 15
     runs-on: ubuntu-latest
-    permissions: {}
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
+
+      - uses: flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1
+        with:
+          bot-id: ${{secrets.TAKUMI_GUARD_BOT_ID}}
+
       - uses: aquaproj/aqua-installer@11dd79b4e498d471a9385aa9fb7f62bb5f52a73c # v4.0.4
         with:
           aqua_version: v2.59.1

--- a/.github/workflows/workflow_call_test.yaml
+++ b/.github/workflows/workflow_call_test.yaml
@@ -1,6 +1,10 @@
 ---
 name: test (workflow_call)
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      TAKUMI_GUARD_BOT_ID:
+        required: true
 permissions: {}
 jobs:
   path-filter:
@@ -29,4 +33,8 @@ jobs:
 
   test:
     uses: ./.github/workflows/workflow_call_go_test.yaml
-    permissions: {}
+    permissions:
+      id-token: write
+      contents: read
+    secrets:
+      TAKUMI_GUARD_BOT_ID: ${{secrets.TAKUMI_GUARD_BOT_ID}}


### PR DESCRIPTION
Introduce takumi guard (Go variant) into the CI workflows to guard Go module downloads during the test job.

## Changes

- `.github/workflows/workflow_call_go_test.yaml`
  - Declared the `TAKUMI_GUARD_BOT_ID` secret (`required: true`) on the `workflow_call` trigger.
  - Added `id-token: write` and `contents: read` permissions to the `test` job (previously `{}`).
  - Inserted the `flatt-security/setup-takumi-guard-golang@2e3c7c40b538cd68b2ac483def12982ebc8bc02e # v1` step (with `bot-id` input) immediately after `actions/setup-go` and before `aquaproj/aqua-installer`, so it is in place before `golangci-lint run` and `go test` download modules.

- `.github/workflows/workflow_call_test.yaml`
  - Declared the `TAKUMI_GUARD_BOT_ID` secret (`required: true`) on the `workflow_call` trigger.
  - Added `id-token: write` and `contents: read` permissions to the `test` job and passed the `TAKUMI_GUARD_BOT_ID` secret down to `workflow_call_go_test.yaml`.

- `.github/workflows/test.yaml`
  - Added `id-token: write` to the `test` job permissions and passed the `TAKUMI_GUARD_BOT_ID` secret down to `workflow_call_test.yaml`, completing the secret/id-token chain from the `pull_request` entrypoint.

The `TAKUMI_GUARD_BOT_ID` secret must be configured in the repository/organization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)